### PR TITLE
Clean country criterion after powsybl 2023.2.1

### DIFF
--- a/src/main/java/org/gridsuite/actions/server/dto/FormContingencyList.java
+++ b/src/main/java/org/gridsuite/actions/server/dto/FormContingencyList.java
@@ -83,8 +83,7 @@ public class FormContingencyList extends AbstractContingencyList {
                 contingencyList = new InjectionCriterionContingencyList(
                         this.getId().toString(),
                         this.getEquipmentType(),
-                        //TODO: replace with "new SingleCountryCriterion(this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList()))" after new powsybl version
-                        this.getCountries1().isEmpty() ? null : new SingleCountryCriterion(this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())),
+                        new SingleCountryCriterion(this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())),
                         NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage1()),
                         Collections.emptyList(),
                         null
@@ -123,8 +122,7 @@ public class FormContingencyList extends AbstractContingencyList {
             case TWO_WINDINGS_TRANSFORMER:
                 contingencyList = new TwoWindingsTransformerCriterionContingencyList(
                         this.getId().toString(),
-                        //TODO: replace with "new SingleCountryCriterion(this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList()))" after new powsybl version
-                        this.getCountries1().isEmpty() ? null : new SingleCountryCriterion(this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())),
+                        new SingleCountryCriterion(this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())),
                         new TwoNominalVoltageCriterion(
                                 NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage1()).getVoltageInterval(),
                                 NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage2()).getVoltageInterval()


### PR DESCRIPTION
Before https://github.com/powsybl/powsybl-core/commit/9f6c4c56a370d4338f8a4c7c7d057c581ce7eafe, no contingency was returned if the country list was empty in the CountryCriterion. We needed to set the countriy list to null. 
Now, an empty country list will returned all the equipment so that we don't need this hack anymore.