### PR TITLE
Add the fields countries and nominalVotlage to contingency list form

### DIFF
--- a/src/main/java/org/gridsuite/actions/server/ContingencyListService.java
+++ b/src/main/java/org/gridsuite/actions/server/ContingencyListService.java
@@ -75,7 +75,7 @@ public class ContingencyListService {
     }
 
     private static FormContingencyList fromFormContingencyListEntity(FormContingencyListEntity entity) {
-        return new FormContingencyList(entity.getId(), entity.getModificationDate(), entity.getEquipmentType(), NumericalFilterEntity.convert(entity.getNominalVoltage1()), NumericalFilterEntity.convert(entity.getNominalVoltage2()), entity.getCountries1(), entity.getCountries2());
+        return new FormContingencyList(entity.getId(), entity.getModificationDate(), entity.getEquipmentType(), NumericalFilterEntity.convert(entity.getNominalVoltage()), NumericalFilterEntity.convert(entity.getNominalVoltage1()), NumericalFilterEntity.convert(entity.getNominalVoltage2()), entity.getCountries(), entity.getCountries1(), entity.getCountries2());
     }
 
     List<PersistentContingencyList> getScriptContingencyLists() {

--- a/src/main/java/org/gridsuite/actions/server/FormToGroovyScript.java
+++ b/src/main/java/org/gridsuite/actions/server/FormToGroovyScript.java
@@ -55,8 +55,8 @@ public class FormToGroovyScript {
     }
 
     private void addCountry(ST template, FormContingencyList formContingencyList) {
-        if (!formContingencyList.getCountries1().isEmpty()) {
-            template.add("countries1", formContingencyList.getCountries1().stream().collect(joining("','", "['", "']")));
+        if (!formContingencyList.getCountries().isEmpty()) {
+            template.add("countries", formContingencyList.getCountries().stream().collect(joining("','", "['", "']")));
         }
     }
 
@@ -138,7 +138,7 @@ public class FormToGroovyScript {
                 addNominalVoltage(template, formContingencyList.getNominalVoltage2(), 0);
             }
         } else {
-            addNominalVoltage(template, formContingencyList.getNominalVoltage1(), 0);
+            addNominalVoltage(template, formContingencyList.getNominalVoltage(), 0);
         }
 
         return template.render();

--- a/src/main/java/org/gridsuite/actions/server/dto/FormContingencyList.java
+++ b/src/main/java/org/gridsuite/actions/server/dto/FormContingencyList.java
@@ -36,11 +36,17 @@ public class FormContingencyList extends AbstractContingencyList {
     @Schema(description = "Equipment type")
     private String equipmentType;
 
+    @Schema(description = "Nominal voltage")
+    private NumericalFilter nominalVoltage;
+
     @Schema(description = "Nominal voltage 1")
     private NumericalFilter nominalVoltage1;
 
     @Schema(description = "Nominal voltage 2")
     private NumericalFilter nominalVoltage2;
+
+    @Schema(description = "Countries")
+    private Set<String> countries;
 
     @Schema(description = "Countries 1")
     private Set<String> countries1;
@@ -51,14 +57,18 @@ public class FormContingencyList extends AbstractContingencyList {
     public FormContingencyList(UUID uuid,
                                Date date,
                                String equipmentType,
+                               NumericalFilter nominalVoltage,
                                NumericalFilter nominalVoltage1,
                                NumericalFilter nominalVoltage2,
+                               Set<String> countries,
                                Set<String> countries1,
                                Set<String> countries2) {
         super(new ContingencyListMetadataImpl(uuid, ContingencyListType.FORM, date));
         this.equipmentType = equipmentType;
+        this.nominalVoltage = nominalVoltage;
         this.nominalVoltage1 = nominalVoltage1;
         this.nominalVoltage2 = nominalVoltage2;
+        this.countries = countries;
         this.countries1 = countries1;
         this.countries2 = countries2;
     }
@@ -68,7 +78,8 @@ public class FormContingencyList extends AbstractContingencyList {
                                NumericalFilter nominalVoltage2,
                                Set<String> countries1,
                                Set<String> countries2) {
-        this(null, null, equipmentType, nominalVoltage1, nominalVoltage2, countries1, countries2);
+        //TODO fix for tests
+        this(null, null, equipmentType, null, nominalVoltage1, nominalVoltage2, null, countries1, countries2);
     }
 
     @Override
@@ -83,8 +94,8 @@ public class FormContingencyList extends AbstractContingencyList {
                 contingencyList = new InjectionCriterionContingencyList(
                         this.getId().toString(),
                         this.getEquipmentType(),
-                        new SingleCountryCriterion(this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())),
-                        NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage1()),
+                        new SingleCountryCriterion(this.getCountries().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())),
+                        NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage()),
                         Collections.emptyList(),
                         null
                 );
@@ -122,7 +133,7 @@ public class FormContingencyList extends AbstractContingencyList {
             case TWO_WINDINGS_TRANSFORMER:
                 contingencyList = new TwoWindingsTransformerCriterionContingencyList(
                         this.getId().toString(),
-                        new SingleCountryCriterion(this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())),
+                        new SingleCountryCriterion(this.getCountries().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())),
                         new TwoNominalVoltageCriterion(
                                 NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage1()).getVoltageInterval(),
                                 NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage2()).getVoltageInterval()

--- a/src/main/java/org/gridsuite/actions/server/dto/FormContingencyList.java
+++ b/src/main/java/org/gridsuite/actions/server/dto/FormContingencyList.java
@@ -74,12 +74,13 @@ public class FormContingencyList extends AbstractContingencyList {
     }
 
     public FormContingencyList(String equipmentType,
+                               NumericalFilter nominalVoltage,
                                NumericalFilter nominalVoltage1,
                                NumericalFilter nominalVoltage2,
+                               Set<String> countries,
                                Set<String> countries1,
                                Set<String> countries2) {
-        //TODO fix for tests
-        this(null, null, equipmentType, null, nominalVoltage1, nominalVoltage2, null, countries1, countries2);
+        this(null, null, equipmentType, nominalVoltage, nominalVoltage1, nominalVoltage2, countries, countries1, countries2);
     }
 
     @Override
@@ -107,9 +108,10 @@ public class FormContingencyList extends AbstractContingencyList {
                                 this.getCountries1().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList()),
                                 this.getCountries2().stream().map(c -> Country.valueOf(c)).collect(Collectors.toList())
                         ),
+                        // TODO ?????
                         new TwoNominalVoltageCriterion(
-                                NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage1()).getVoltageInterval(),
-                                NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage2()).getVoltageInterval()
+                                NumericalFilter.toNominalVoltageCriterion(this.getNominalVoltage()).getVoltageInterval(),
+                                null
                         ),
                         Collections.emptyList(),
                         null

--- a/src/main/java/org/gridsuite/actions/server/entities/FormContingencyListEntity.java
+++ b/src/main/java/org/gridsuite/actions/server/entities/FormContingencyListEntity.java
@@ -33,6 +33,14 @@ public class FormContingencyListEntity extends AbstractContingencyEntity {
     private String equipmentType;
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "numericFilterId_id",
+            referencedColumnName = "id",
+            foreignKey = @ForeignKey(
+                    name = "numericFilterId_id_fk"
+            ), nullable = true)
+    NumericalFilterEntity nominalVoltage;
+
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "numericFilterId1_id",
             referencedColumnName = "id",
             foreignKey = @ForeignKey(
@@ -47,6 +55,11 @@ public class FormContingencyListEntity extends AbstractContingencyEntity {
                     name = "numericFilterId_id_fk2"
             ), nullable = true)
     NumericalFilterEntity nominalVoltage2;
+
+    @Column(name = "country")
+    @ElementCollection
+    @CollectionTable(foreignKey = @ForeignKey(name = "formContingencyListEntity_countries_fk"), indexes = {@Index(name = "formContingencyListEntity_countries_idx", columnList = "form_contingency_list_entity_id")})
+    private Set<String> countries;
 
     @Column(name = "country1")
     @ElementCollection
@@ -67,18 +80,18 @@ public class FormContingencyListEntity extends AbstractContingencyEntity {
     final void init(FormContingencyList formContingencyList) {
         this.equipmentType = formContingencyList.getEquipmentType();
         EquipmentType type = EquipmentType.valueOf(this.equipmentType);
-        this.nominalVoltage1 = NumericalFilterEntity.convert(formContingencyList.getNominalVoltage1());
         // protection against unrelevant input data
         if (type == EquipmentType.TWO_WINDINGS_TRANSFORMER || type == EquipmentType.LINE) {
+            this.nominalVoltage1 = NumericalFilterEntity.convert(formContingencyList.getNominalVoltage1());
             this.nominalVoltage2 = NumericalFilterEntity.convert(formContingencyList.getNominalVoltage2());
         } else {
-            this.nominalVoltage2 = null;
+            this.nominalVoltage = NumericalFilterEntity.convert(formContingencyList.getNominalVoltage());
         }
-        this.countries1 = new HashSet<>(emptyIfNull(formContingencyList.getCountries1()));
         if (type == EquipmentType.LINE || type == EquipmentType.HVDC_LINE) {
+            this.countries1 = new HashSet<>(emptyIfNull(formContingencyList.getCountries1()));
             this.countries2 = new HashSet<>(emptyIfNull(formContingencyList.getCountries2()));
         } else {
-            this.countries2 = null;
+            this.countries = new HashSet<>(emptyIfNull(formContingencyList.getCountries()));
         }
     }
 

--- a/src/main/resources/db/changelog/changesets/changelog_20230706T144551Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20230706T144551Z.xml
@@ -24,4 +24,32 @@
     <changeSet author="florent (generated)" id="1688654755015-5">
         <addForeignKeyConstraint baseColumnNames="numeric_filter_id_id" baseTableName="form_contingency_list" constraintName="numericFilterId_id_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="numeric_filter" validate="true"/>
     </changeSet>
+    <changeSet author="florent" id="1688654755015-6">
+        <update tableName="form_contingency_list">
+            <column name="numeric_filter_id_id" valueComputed="numeric_filter_id1_id"/>
+            <where>equipment_type!='TWO_WINDINGS_TRANSFORMER' AND equipment_type!='LINE'</where>
+        </update>
+    </changeSet>
+    <changeSet author="florent" id="1688654755015-7">
+        <update tableName="form_contingency_list">
+            <column name="numeric_filter_id1_id"/>
+            <where>equipment_type!='TWO_WINDINGS_TRANSFORMER' AND equipment_type!='LINE'</where>
+        </update>
+    </changeSet>
+    <changeSet author="florent" id="1688654755015-8">
+        <sql>
+            INSERT INTO form_contingency_list_entity_countries (form_contingency_list_entity_id, country)
+            SELECT form_contingency_list_entity_id, country1
+            FROM form_contingency_list_entity_countries1
+            WHERE form_contingency_list_entity_id IN (SELECT id FROM form_contingency_list WHERE equipment_type!='HVDC_LINE'
+              AND equipment_type!='LINE')
+        </sql>
+    </changeSet>
+    <changeSet author="florent" id="1688654755015-9">
+        <sql>
+            DELETE FROM form_contingency_list_entity_countries1
+            WHERE form_contingency_list_entity_id IN (SELECT id FROM form_contingency_list WHERE equipment_type!='HVDC_LINE'
+              AND equipment_type!='LINE')
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changesets/changelog_20230706T144551Z.xml
+++ b/src/main/resources/db/changelog/changesets/changelog_20230706T144551Z.xml
@@ -1,0 +1,27 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:pro="http://www.liquibase.org/xml/ns/pro" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.1.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="florent (generated)" id="1688654755015-1">
+        <createTable tableName="form_contingency_list_entity_countries">
+            <column name="form_contingency_list_entity_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="country" type="VARCHAR(255)"/>
+        </createTable>
+    </changeSet>
+    <changeSet author="florent (generated)" id="1688654755015-2">
+        <addColumn tableName="form_contingency_list">
+            <column name="numeric_filter_id_id" type="uuid"/>
+        </addColumn>
+    </changeSet>
+    <changeSet author="florent (generated)" id="1688654755015-3">
+        <createIndex indexName="formContingencyListEntity_countries_idx" tableName="form_contingency_list_entity_countries">
+            <column name="form_contingency_list_entity_id"/>
+        </createIndex>
+    </changeSet>
+    <changeSet author="florent (generated)" id="1688654755015-4">
+        <addForeignKeyConstraint baseColumnNames="form_contingency_list_entity_id" baseTableName="form_contingency_list_entity_countries" constraintName="formContingencyListEntity_countries_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="form_contingency_list" validate="true"/>
+    </changeSet>
+    <changeSet author="florent (generated)" id="1688654755015-5">
+        <addForeignKeyConstraint baseColumnNames="numeric_filter_id_id" baseTableName="form_contingency_list" constraintName="numericFilterId_id_fk" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="numeric_filter" validate="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -27,3 +27,7 @@ databaseChangeLog:
   - include:
       file: changesets/changelog_20230313T145947Z.xml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/changelog_20230706T144551Z.xml
+      relativeToChangelogFile: true

--- a/src/main/resources/injection.st
+++ b/src/main/resources/injection.st
@@ -1,11 +1,11 @@
 for (equipment in network.<collectionName>) {
-  <if(nominalV || nominalVMin || countries1)>if (<if(nominalV)>(equipment.terminal.voltageLevel.nominalV <nominalVOperator> <nominalV>)<endif>
+  <if(nominalV || nominalVMin || countries)>if (<if(nominalV)>(equipment.terminal.voltageLevel.nominalV <nominalVOperator> <nominalV>)<endif>
     <if(nominalVMin)>(equipment.terminal.voltageLevel.nominalV >= <nominalVMin> && equipment.terminal.voltageLevel.nominalV \<= <nominalVMax>)<endif>
-    <if((nominalV || nominalVMin) && countries1)>&& <endif><if(countries1)>injectionMatch(equipment.terminal, <countries1>)<endif>
+    <if((nominalV || nominalVMin) && countries)>&& <endif><if(countries)>injectionMatch(equipment.terminal, <countries>)<endif>
    ) {
    <endif>
         contingency(equipment.id) { equipments equipment.id }
-   <if(nominalV || nominalVMin || countries1)>
+   <if(nominalV || nominalVMin || countries)>
   }
   <endif>
 }

--- a/src/main/resources/transfo2W.st
+++ b/src/main/resources/transfo2W.st
@@ -1,5 +1,5 @@
 for (equipment in network.<collectionName>) {
-  <if(nominalV || nominalVMin || nominalV1 || nominalV2 || nominalVMin1 || nominalVMin2 || countries1)>if (
+  <if(nominalV || nominalVMin || nominalV1 || nominalV2 || nominalVMin1 || nominalVMin2 || countries)>if (
      <if(nominalV)>(equipment.terminal1.voltageLevel.nominalV <nominalVOperator> <nominalV>
      || equipment.terminal2.voltageLevel.nominalV <nominalVOperator> <nominalV>)<endif>
      <if(nominalVMin)>((equipment.terminal1.voltageLevel.nominalV >= <nominalVMin> && equipment.terminal1.voltageLevel.nominalV \<= <nominalVMax>)
@@ -12,12 +12,12 @@ for (equipment in network.<collectionName>) {
      || (equipment.terminal1.voltageLevel.nominalV <nominalVOperator2> <nominalV2> && equipment.terminal2.voltageLevel.nominalV >= <nominalVMin1> && equipment.terminal2.voltageLevel.nominalV \<= <nominalVMax1>))<endif>
      <if(nominalVMin1 && nominalVMin2)>((equipment.terminal1.voltageLevel.nominalV >= <nominalVMin1> && equipment.terminal1.voltageLevel.nominalV \<= <nominalVMax1> && equipment.terminal2.voltageLevel.nominalV >= <nominalVMin2> && equipment.terminal2.voltageLevel.nominalV \<= <nominalVMax2>)
      || (equipment.terminal1.voltageLevel.nominalV >= <nominalVMin2> && equipment.terminal1.voltageLevel.nominalV \<= <nominalVMax2> && equipment.terminal2.voltageLevel.nominalV >= <nominalVMin1> && equipment.terminal2.voltageLevel.nominalV \<= <nominalVMax1>))<endif>
-     <if((nominalV || nominalVMin || nominalV1 || nominalV2 || nominalVMin1 || nominalVMin2) && countries1)>
-     && <endif><if(countries1)>transfoMatch(equipment, <countries1>)<endif>
+     <if((nominalV || nominalVMin || nominalV1 || nominalV2 || nominalVMin1 || nominalVMin2) && countries)>
+     && <endif><if(countries)>transfoMatch(equipment, <countries>)<endif>
    ) {
      <endif>
            contingency(equipment.id) { equipments equipment.id }
-   <if(nominalV || nominalVMin || nominalV1 || nominalV2 || nominalVMin1 || nominalVMin2 || countries1)>
+   <if(nominalV || nominalVMin || nominalV1 || nominalV2 || nominalVMin1 || nominalVMin2 || countries)>
   }
   <endif>
 }

--- a/src/test/java/org/gridsuite/actions/test/GenerateScriptFromFiltersTest.java
+++ b/src/test/java/org/gridsuite/actions/test/GenerateScriptFromFiltersTest.java
@@ -36,8 +36,8 @@ public class GenerateScriptFromFiltersTest {
                 "        contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-            "GENERATOR", new NumericalFilter(NumericalFilterOperator.EQUALITY, 90., null), null,
-            countries, new HashSet<>())));
+            "GENERATOR", new NumericalFilter(NumericalFilterOperator.EQUALITY, 90., null), null, null,
+            countries, new HashSet<>(), new HashSet<>())));
 
         assertEquals("for (equipment in network.danglingLines) {\n" +
             "  if ((equipment.terminal.voltageLevel.nominalV == 225.0)\n" +
@@ -45,14 +45,14 @@ public class GenerateScriptFromFiltersTest {
             "        contingency(equipment.id) { equipments equipment.id }\n" +
             "  }\n" +
             "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-            "DANGLING_LINE", new NumericalFilter(NumericalFilterOperator.EQUALITY, 225., null), null,
-                new HashSet<>(), new HashSet<>())));
+            "DANGLING_LINE", new NumericalFilter(NumericalFilterOperator.EQUALITY, 225., null), null, null,
+                new HashSet<>(), new HashSet<>(), new HashSet<>())));
 
         assertEquals("for (equipment in network.staticVarCompensators) {\n" +
             "        contingency(equipment.id) { equipments equipment.id }\n" +
             "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-            "STATIC_VAR_COMPENSATOR", null, null,
-                new HashSet<>(), new HashSet<>())));
+            "STATIC_VAR_COMPENSATOR", null, null, null,
+                new HashSet<>(), new HashSet<>(), new HashSet<>())));
 
         assertEquals("for (equipment in network.shuntCompensators) {\n" +
             "  if ((equipment.terminal.voltageLevel.nominalV < 90.0)\n" +
@@ -60,8 +60,8 @@ public class GenerateScriptFromFiltersTest {
             "        contingency(equipment.id) { equipments equipment.id }\n" +
             "  }\n" +
             "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-            "SHUNT_COMPENSATOR", new NumericalFilter(NumericalFilterOperator.LESS_THAN, 90., null), null,
-                new HashSet<>(), new HashSet<>())));
+            "SHUNT_COMPENSATOR", new NumericalFilter(NumericalFilterOperator.LESS_THAN, 90., null), null, null,
+                new HashSet<>(), new HashSet<>(), new HashSet<>())));
 
         assertEquals("for (equipment in network.shuntCompensators) {\n" +
                 "  if ((equipment.terminal.voltageLevel.nominalV > 90.0)\n" +
@@ -69,8 +69,8 @@ public class GenerateScriptFromFiltersTest {
                 "        contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "SHUNT_COMPENSATOR", new NumericalFilter(NumericalFilterOperator.GREATER_THAN, 90., null), null,
-                    new HashSet<>(), new HashSet<>())));
+                "SHUNT_COMPENSATOR", new NumericalFilter(NumericalFilterOperator.GREATER_THAN, 90., null), null, null,
+                    new HashSet<>(), new HashSet<>(), new HashSet<>())));
 
         assertEquals("for (equipment in network.busbarSections) {\n" +
             "  if ((equipment.terminal.voltageLevel.nominalV >= 63.0)\n" +
@@ -79,8 +79,8 @@ public class GenerateScriptFromFiltersTest {
             "        contingency(equipment.id) { equipments equipment.id }\n" +
             "  }\n" +
             "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-            "BUSBAR_SECTION", new NumericalFilter(NumericalFilterOperator.GREATER_OR_EQUAL, 63., null), null,
-            countries, new HashSet<>())));
+            "BUSBAR_SECTION", new NumericalFilter(NumericalFilterOperator.GREATER_OR_EQUAL, 63., null), null, null,
+            countries, new HashSet<>(), new HashSet<>())));
     }
 
     @Test
@@ -99,8 +99,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "HVDC_LINE", null, null,
-                countries, new HashSet<>())));
+                "HVDC_LINE", null, null, null,
+                    new HashSet<>(), countries, new HashSet<>())));
 
         assertEquals("for (equipment in network.hvdcLines) {\n" +
                 "  if ((equipment.nominalV <= 225.0)\n" +
@@ -109,8 +109,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "HVDC_LINE", new NumericalFilter(NumericalFilterOperator.LESS_OR_EQUAL, 225., null), null,
-                countries, new HashSet<>())));
+                "HVDC_LINE", new NumericalFilter(NumericalFilterOperator.LESS_OR_EQUAL, 225., null), null, null,
+                    new HashSet<>(), countries, new HashSet<>())));
 
         assertEquals("for (equipment in network.hvdcLines) {\n" +
                 "  if ((equipment.nominalV <= 225.0)\n" +
@@ -119,8 +119,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "HVDC_LINE", new NumericalFilter(NumericalFilterOperator.LESS_OR_EQUAL, 225., null), null,
-                countries, countries2)));
+                "HVDC_LINE", new NumericalFilter(NumericalFilterOperator.LESS_OR_EQUAL, 225., null), null, null,
+                    new HashSet<>(), countries, countries2)));
 
         assertEquals("for (equipment in network.hvdcLines) {\n" +
                 "  if ((equipment.nominalV <= 225.0)\n" +
@@ -129,8 +129,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "HVDC_LINE", new NumericalFilter(NumericalFilterOperator.LESS_OR_EQUAL, 225., null), null,
-                    new HashSet<>(), countries2)));
+                "HVDC_LINE", new NumericalFilter(NumericalFilterOperator.LESS_OR_EQUAL, 225., null), null, null,
+                    new HashSet<>(), new HashSet<>(), countries2)));
     }
 
     @Test
@@ -151,8 +151,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "LINE", new NumericalFilter(NumericalFilterOperator.EQUALITY, 225., null), null,
-                    new HashSet<>(), new HashSet<>())));
+                "LINE", null, new NumericalFilter(NumericalFilterOperator.EQUALITY, 225., null), null,
+                    new HashSet<>(), new HashSet<>(), new HashSet<>())));
 
         assertEquals("for (equipment in network.lines) {\n" +
                 "  if (\n" +
@@ -161,8 +161,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "LINE", null, null,
-                countries, countries2)));
+                "LINE", null, null, null,
+                    new HashSet<>(), countries, countries2)));
 
         assertEquals("for (equipment in network.lines) {\n" +
                 "  if (\n" +
@@ -171,8 +171,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "LINE", null, null,
-                countries, new HashSet<>())));
+                "LINE", null, null, null,
+                    new HashSet<>(), countries, new HashSet<>())));
 
         assertEquals("for (equipment in network.lines) {\n" +
                 "  if (\n" +
@@ -181,8 +181,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(new FormContingencyList(
-                "LINE", null, null,
-                    new HashSet<>(), countries2)));
+                "LINE", null, null, null,
+                    new HashSet<>(), new HashSet<>(), countries2)));
     }
 
     @Test
@@ -201,8 +201,8 @@ public class GenerateScriptFromFiltersTest {
                 "           contingency(equipment.id) { equipments equipment.id }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", null, null,
-                        new HashSet<>(), new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, null, null,
+                        new HashSet<>(), new HashSet<>(), new HashSet<>()
                 )));
 
         assertEquals("for (equipment in network.twoWindingsTransformers) {\n" +
@@ -215,8 +215,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", ge225, null,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, ge225, null,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // same filter, but in second position => same result
@@ -230,8 +230,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", null, ge225,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, null, ge225,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // just one range on filter 1
@@ -245,8 +245,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", range225400, null,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, range225400, null,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // same on filter 2
@@ -260,8 +260,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", null, range225400,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, null, range225400,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // simple operator on filter 1 & 2
@@ -275,8 +275,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", lt400, ge225,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, lt400, ge225,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // switch
@@ -290,8 +290,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", ge225, lt400,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, ge225, lt400,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // simple operator on filter 1, range on filter 2
@@ -305,8 +305,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", lt400, range225400,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, lt400, range225400,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // switch
@@ -320,8 +320,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", range225400, lt400,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, range225400, lt400,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // range operator on filter 1 & 2
@@ -335,8 +335,8 @@ public class GenerateScriptFromFiltersTest {
                 "  }\n" +
                 "}\n\n\n", formToScript.generateGroovyScriptFromForm(
                     new FormContingencyList(
-                        "TWO_WINDINGS_TRANSFORMER", range225400, range2063,
-                        countries, new HashSet<>()
+                        "TWO_WINDINGS_TRANSFORMER", null, range225400, range2063,
+                        countries, new HashSet<>(), new HashSet<>()
                 )));
 
         // just for better coverage: RANGE has no basic operator


### PR DESCRIPTION
Add the fields countries and nominalVotlage for DTO and entities in order to use the same form schema the filters use.
Then more coherence between actions server and filter server, and avoid duplication of code in gridexplore.