### PR TITLE
Update workflow references and add force-release option

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -9,16 +9,15 @@ on:
 
 jobs:
   run-patch:
-    uses: powsybl/github-ci/.github/workflows/patch-generic.yml@baf0d2ed84b70d359132693880d5e530cd93f168
+    uses: powsybl/github-ci/.github/workflows/patch-generic.yml@v1
     with:
       githubappId: ${{ vars.GRIDSUITE_ACTIONS_APPID }}
-      sonarOrganization: gridsuite
-      sonarProjectKey: org.gridsuite:actions-server
-      dockerImage: docker.io/gridsuite/actions-server
-      dockerUsername: gridsuiteci
+      sonarOrganization: ${{ vars.SONAR_ORGANIZATION }}
+      sonarProjectKey: ${{ vars.SONAR_PROJECT_KEY }}
+      dockerImage: ${{ vars.DOCKER_IMAGE }}
+      dockerUsername: ${{ vars.DOCKER_USERNAME }}
       releaseVersion: ${{ github.event.inputs.releaseVersion }}
     secrets:
       githubappPrivateKey: ${{ secrets.GRIDSUITE_ACTIONS_SECRET }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}
       docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,18 +9,24 @@ on:
       gitReference:
         description: SHA of the commit from where to release or branch name
         required: true
+      force-release:
+        description: Force the release even if it already exists
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   run-release:
-    uses: powsybl/github-ci/.github/workflows/release-generic.yml@baf0d2ed84b70d359132693880d5e530cd93f168
+    uses: powsybl/github-ci/.github/workflows/release-generic.yml@v1
     with:
       githubappId: ${{ vars.GRIDSUITE_ACTIONS_APPID }}
-      sonarOrganization: gridsuite
-      sonarProjectKey: org.gridsuite:actions-server
-      dockerImage: docker.io/gridsuite/actions-server
-      dockerUsername: gridsuiteci
+      sonarOrganization: ${{ vars.SONAR_ORGANIZATION }}
+      sonarProjectKey: ${{ vars.SONAR_PROJECT_KEY }}
+      dockerImage: ${{ vars.DOCKER_IMAGE }}
+      dockerUsername: ${{ vars.DOCKER_USERNAME }}
       releaseVersion: ${{ github.event.inputs.releaseVersion }}
       gitReference: ${{ github.event.inputs.gitReference }}
+      force-release: ${{ github.event.inputs.force-release }}
     secrets:
       githubappPrivateKey: ${{ secrets.GRIDSUITE_ACTIONS_SECRET }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Changes

1. Update workflow references to use tag instead of SHA
2. Add force-release parameter to release workflow
3. References updated to use v1 tag

This allows for:
- Automatic updates within major version
- Ability to force a release when needed
- Better version management