### PR TITLE
Update workflow references and add force-release option

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   run-patch:
-    uses: powsybl/github-ci/.github/workflows/patch-generic.yml@baf0d2ed84b70d359132693880d5e530cd93f168
+    uses: powsybl/github-ci/.github/workflows/patch-generic.yml@v1
     with:
       githubappId: ${{ vars.GRIDSUITE_ACTIONS_APPID }}
       sonarOrganization: gridsuite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   run-release:
-    uses: powsybl/github-ci/.github/workflows/release-generic.yml@baf0d2ed84b70d359132693880d5e530cd93f168
+    uses: powsybl/github-ci/.github/workflows/release-generic.yml@v1
     with:
       githubappId: ${{ vars.GRIDSUITE_ACTIONS_APPID }}
       sonarOrganization: gridsuite
@@ -21,6 +21,7 @@ jobs:
       dockerUsername: gridsuiteci
       releaseVersion: ${{ github.event.inputs.releaseVersion }}
       gitReference: ${{ github.event.inputs.gitReference }}
+      force-release: ${{ github.event.inputs.force-release }}
     secrets:
       githubappPrivateKey: ${{ secrets.GRIDSUITE_ACTIONS_SECRET }}
       sonar-token: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Changes

1. Update workflow references to use tag instead of SHA
2. Add force-release parameter to release workflow
3. References updated to use v1 tag

This allows for:
- Automatic updates within major version
- Ability to force a release when needed
- Better version management