### PR TITLE
Remove userId from filter-server call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,8 @@
         <liquibase-hibernate-package>org.gridsuite.actions.server</liquibase-hibernate-package>
         <sonar.organization>gridsuite</sonar.organization>
         <sonar.projectKey>org.gridsuite:actions-server</sonar.projectKey>
+        <!-- FIXME to remove at next upgrade of gridsuite-dependencies -->
+        <gridsuite-actions.version>0.7.0</gridsuite-actions.version>
     </properties>
 
     <build>
@@ -84,7 +86,13 @@
 
     <dependencyManagement>
         <dependencies>
-
+            <!-- overrides of imports -->
+            <!-- FIXME to remove at next upgrade of gridsuite-dependencies -->
+            <dependency>
+                <groupId>org.gridsuite</groupId>
+                <artifactId>gridsuite-actions</artifactId>
+                <version>${gridsuite-actions.version}</version>
+            </dependency>
             <!-- imports -->
             <dependency>
                 <groupId>org.gridsuite</groupId>

--- a/src/main/java/org/gridsuite/actions/server/ContingencyListController.java
+++ b/src/main/java/org/gridsuite/actions/server/ContingencyListController.java
@@ -173,9 +173,8 @@ public class ContingencyListController {
     @Operation(summary = "Get filter based contingency list by id")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "The filter based contingency list"),
         @ApiResponse(responseCode = "404", description = "The filter based contingency list does not exists")})
-    public ResponseEntity<FilterBasedContingencyList> getFilterBasedContingencyList(@PathVariable("id") UUID id,
-                                                                                    @RequestHeader("userId") String userId) {
-        return service.getFilterBasedContingencyList(id, userId).map(contingencyList -> ResponseEntity.ok()
+    public ResponseEntity<FilterBasedContingencyList> getFilterBasedContingencyList(@PathVariable("id") UUID id) {
+        return service.getFilterBasedContingencyList(id).map(contingencyList -> ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(contingencyList))
             .orElse(ResponseEntity.notFound().build());

--- a/src/main/java/org/gridsuite/actions/server/ContingencyListService.java
+++ b/src/main/java/org/gridsuite/actions/server/ContingencyListService.java
@@ -111,7 +111,7 @@ public class ContingencyListService {
     }
 
     @Transactional
-    public Optional<FilterBasedContingencyList> getFilterBasedContingencyList(UUID id, String userId) {
+    public Optional<FilterBasedContingencyList> getFilterBasedContingencyList(UUID id) {
         Optional<FilterBasedContingencyListEntity> entity = doGetFilterBasedContingencyListEntity(id);
         if (entity.isEmpty()) {
             return Optional.empty();
@@ -122,7 +122,7 @@ public class ContingencyListService {
                 .map(EquipmentTypesByFilterEntity::toDto)
                 .toList();
             //get information from filterServer
-            List<FilterAttributes> attributes = filterService.getFiltersAttributes(filterIds, userId);
+            List<FilterAttributes> attributes = filterService.getFiltersAttributes(filterIds);
             return Optional.of(new FilterBasedContingencyList(entity.get().getId(), entity.get().getModificationDate(), attributes, selectedEquipmentTypesByFilter));
         }
     }

--- a/src/main/java/org/gridsuite/actions/server/ContingencyListService.java
+++ b/src/main/java/org/gridsuite/actions/server/ContingencyListService.java
@@ -307,7 +307,7 @@ public class ContingencyListService {
 
     private static FilterBasedContingencyList fromFilterBasedContingencyListEntity(FilterBasedContingencyListEntity entity) {
         return new FilterBasedContingencyList(entity.getId(), entity.getModificationDate(),
-            entity.getFiltersIds().stream().map(uuid -> new FilterAttributes(uuid, null, null)).toList(),
+            entity.getFiltersIds().stream().map(uuid -> new FilterAttributes(uuid, null)).toList(),
             entity.getSelectedEquipmentTypesByFilter().stream().map(EquipmentTypesByFilterEntity::toDto).toList());
     }
 

--- a/src/main/java/org/gridsuite/actions/server/service/FilterService.java
+++ b/src/main/java/org/gridsuite/actions/server/service/FilterService.java
@@ -42,7 +42,7 @@ public class FilterService {
         this.restTemplate = restTemplateBuilder.build();
     }
 
-    public List<FilterAttributes> getFiltersAttributes(List<UUID> filtersUuid, String userId) {
+    public List<FilterAttributes> getFiltersAttributes(List<UUID> filtersUuid) {
         if (filtersUuid.isEmpty()) {
             return new ArrayList<>();
         }
@@ -52,7 +52,6 @@ public class FilterService {
         var uriComponent = uriComponentsBuilder.buildAndExpand();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.set("userId", userId);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<List<FilterAttributes>> response = restTemplate.exchange(uriComponent.toUriString(),

--- a/src/test/java/org/gridsuite/actions/server/ContingencyListControllerTest.java
+++ b/src/test/java/org/gridsuite/actions/server/ContingencyListControllerTest.java
@@ -333,8 +333,7 @@ class ContingencyListControllerTest {
         FilterBasedContingencyList filterBasedContingencyList = addNewFilterBasedContingencyList(list);
 
         // test get
-        MappingBuilder requestPatternBuilder = WireMock.get(WireMock.urlPathEqualTo("/v1/filters/infos"))
-            .withHeader(USER_ID_HEADER, WireMock.equalTo(USER_ID_HEADER));
+        MappingBuilder requestPatternBuilder = WireMock.get(WireMock.urlPathEqualTo("/v1/filters/infos"));
 
         for (UUID filter : filters) {
             requestPatternBuilder.withQueryParam("filterUuids", WireMock.equalTo(filter.toString()));
@@ -343,7 +342,6 @@ class ContingencyListControllerTest {
         wireMockServer.stubFor(requestPatternBuilder.willReturn(WireMock.ok()));
 
         mvc.perform(get("/" + VERSION + "/filters-contingency-lists/" + filterBasedContingencyList.getId())
-                .header(USER_ID_HEADER, USER_ID_HEADER)
                 .contentType(APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().contentTypeCompatibleWith(APPLICATION_JSON));

--- a/src/test/java/org/gridsuite/actions/server/ContingencyListControllerTest.java
+++ b/src/test/java/org/gridsuite/actions/server/ContingencyListControllerTest.java
@@ -189,9 +189,9 @@ class ContingencyListControllerTest {
     private String genFilterBasedContingencyList(List<UUID> uuids) throws JsonProcessingException {
 
         List<FilterAttributes> filtersAttributes = List.of(
-            new FilterAttributes(uuids.get(0), LINE, "Filter1"),
-            new FilterAttributes(uuids.get(1), SUBSTATION, "Filter2"),
-            new FilterAttributes(uuids.get(2), TWO_WINDINGS_TRANSFORMER, "Filter3")
+            new FilterAttributes(uuids.get(0), LINE),
+            new FilterAttributes(uuids.get(1), SUBSTATION),
+            new FilterAttributes(uuids.get(2), TWO_WINDINGS_TRANSFORMER)
         );
         List<EquipmentTypesByFilter> equipmentTypesByFilter = List.of(
             new EquipmentTypesByFilter(uuids.get(1), Set.of(IdentifiableType.GENERATOR))
@@ -203,8 +203,8 @@ class ContingencyListControllerTest {
     private String genModifiedFilterBasedContingencyList(List<UUID> uuids) throws JsonProcessingException {
 
         List<FilterAttributes> filtersAttributes = List.of(
-            new FilterAttributes(uuids.get(0), LINE, "Filter1"),
-            new FilterAttributes(uuids.get(2), TWO_WINDINGS_TRANSFORMER, "Filter3")
+            new FilterAttributes(uuids.get(0), LINE),
+            new FilterAttributes(uuids.get(2), TWO_WINDINGS_TRANSFORMER)
         );
         return "{\"type\":" + "\"FILTERS\"" + ", \"filters\":" + objectMapper.writeValueAsString(filtersAttributes) + ", \"selectedEquipmentTypesByFilter\":[]}";
     }


### PR DESCRIPTION
## PR Summary
<!-- Briefly summarize the changes: what it was before, what it is after, and any important notes for reviewers. -->

This PR updates the `actions-server` so that it no longer sends the `userId` body parameter when calling certain `filter-server` endpoints, as it is no longer required.


